### PR TITLE
Development & Release configuration + xcode schema run from xcode , display name, bundle identifier, run from vs code fix, improve read me etc.

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -3,5 +3,7 @@
 - 
 
 **Screen shots**  
+- NA
 
-**Api logs**  
+**Api logs** 
+- NA 

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,7 @@
+
+**What**  
+- 
+
+**Screen shots**  
+
+**Api logs**  

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,9 +1,23 @@
+### Issue
 
-**What**  
-- 
+- close `(required: Put the ticket link)`
 
-**Screen shots**  
-- NA
+### Motivation and Context
 
-**Api logs** 
-- NA 
+- `(required)`
+
+### Modified points
+
+- [ ] `(required: Write "What you did" here)`
+
+### Description and Screenshots
+
+- `(optional)`
+
+### Figma or screen image URL
+
+- `(required)`
+
+### Worries or Issues
+
+- `(optional)`

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,24 +5,25 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "flutter_template_riverpod",
+      "name": "flutter_template_riverpod(development mode)",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main/main_development.dart"
-    },
-    {
-      "name": "flutter_template_riverpod (profile mode)",
-      "request": "launch",
-      "type": "dart",
-      "flutterMode": "profile",
-      "program": "lib/main/main_production.dart"
+      "program": "lib/main/main_development.dart",
+      "args": [
+        "--flavor",
+        "Development",
+       ]
     },
     {
       "name": "flutter_template_riverpod (release mode)",
       "request": "launch",
       "type": "dart",
       "flutterMode": "release",
-      "program": "lib/main/main_production.dart"
+      "program": "lib/main/main_production.dart",
+      "args": [
+        "--flavor",
+        "Release",
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "program": "lib/main/main_production.dart",
       "args": [
         "--flavor",
-        "Release",
+        "Production",
       ]
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "flutter_template_riverpod(development mode)",
+      "name": "flutter_template_riverpod (development mode)",
       "request": "launch",
       "type": "dart",
       "program": "lib/main/main_development.dart",

--- a/README.md
+++ b/README.md
@@ -1,37 +1,67 @@
 # flutter_template_riverpod
 
-MonstarLab Flutter Template w/Riverpod 2.x
+MonstarLab Flutter Template w/Riverpod
 
-## Premise
+## Getting Started
 
-Based loosely around the
-prior [MonstarLab Flutter Template](https://github.com/monstar-lab-oss/flutter-template) which uses
-BLOC instead of Riverpod. The main theme is Anime News. The API used
-is [Jikan API (4.0.0)](https://docs.api.jikan.moe) which is an unofficial API for the well
-known [MyAnimeList](https://myanimelist.net/) website. No API key is required as of creation, making
-it ideal for a demo/template.
+This project is a starting point for a Flutter application.
 
-## Concepts demonstrated
+A few resources to get you started if this is your first Flutter project:
 
-- [Flutter Riverpod Architecture](https://codewithandrea.com/articles/flutter-app-architecture-riverpod-introduction/)
-  - Presentation, Application, Domain and Data Layers.
-- Freezed Code Generation
-- Riverpod Provider Generation
-- Retrofit API calls, `toJson` function Generation.
+- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
 
-## How to run
+For help getting started with Flutter development, view the
+[online documentation](https://docs.flutter.dev/), which offers tutorials, samples, guidance on
+mobile development, and a full API reference.
 
+## How to build
 - run below command
-
 ```
 flutter pub get
 flutter packages pub run build_runner build --delete-conflicting-outputs
 ```
 
-### Visual Studio
+## Run 
+### Run iOS/Android using Visual Studio
+- create launch.json and add add below
+```
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "flutter_template_riverpod(development mode)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main/main_development.dart",
+      "args": [
+        "--flavor",
+        "Development",
+       ]
+    },
+    {
+      "name": "flutter_template_riverpod (release mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "release",
+      "program": "lib/main/main_production.dart",
+      "args": [
+        "--flavor",
+        "Release",
+      ]
+    }
+  ]
+}
+```
 
-Launch Configurations are included in the `.vscode/launch.json` file.
+### run iOS/Android From terminal
+```
+- flutter run --flavor Development -t lib/main/main_development.dart
+```
 
-### Android Studio
-
-Launch Configurations are included in the `.run` folder. 
+### run iOS using xcode
+- Select Development schema from top center and run in development mode(Debug)
+- Should select Production for archive release mode ipa file

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ flutter packages pub run build_runner build --delete-conflicting-outputs
 
 ## Run 
 ### Run iOS/Android using Visual Studio
-- create launch.json and add add below
+- create launch.json and add below
 ```
 {
   // Use IntelliSense to learn about possible attributes.

--- a/README.md
+++ b/README.md
@@ -36,38 +36,7 @@ Launch Configurations are included in the `.run` folder.
 
 
 ### Run iOS/Android using Visual Studio
-- create launch.json and add below
-```
-{
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "flutter_template_riverpod (development mode)",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main/main_development.dart",
-      "args": [
-        "--flavor",
-        "Development",
-       ]
-    },
-    {
-      "name": "flutter_template_riverpod (release mode)",
-      "request": "launch",
-      "type": "dart",
-      "flutterMode": "release",
-      "program": "lib/main/main_production.dart",
-      "args": [
-        "--flavor",
-        "Release",
-      ]
-    }
-  ]
-}
-```
+- Follow .vscode/launch.json
 
 ### run iOS/Android From terminal
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # flutter_template_riverpod
 
-MonstarLab Flutter Template w/Riverpod
+MonstarLab Flutter Template w/Riverpod 2.x
 
-## Getting Started
+## Premise
 
-This project is a starting point for a Flutter application.
+Based loosely around the
+prior [MonstarLab Flutter Template](https://github.com/monstar-lab-oss/flutter-template) which uses
+BLOC instead of Riverpod. The main theme is Anime News. The API used
+is [Jikan API (4.0.0)](https://docs.api.jikan.moe) which is an unofficial API for the well
+known [MyAnimeList](https://myanimelist.net/) website. No API key is required as of creation, making
+it ideal for a demo/template.
 
-A few resources to get you started if this is your first Flutter project:
+## Concepts demonstrated
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+- [Flutter Riverpod Architecture](https://codewithandrea.com/articles/flutter-app-architecture-riverpod-introduction/)
+  - Presentation, Application, Domain and Data Layers.
+- Freezed Code Generation
+- Riverpod Provider Generation
+- Retrofit API calls, `toJson` function Generation.
 
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials, samples, guidance on
@@ -23,6 +31,10 @@ flutter packages pub run build_runner build --delete-conflicting-outputs
 ```
 
 ## Run 
+### Android Studio
+Launch Configurations are included in the `.run` folder. 
+
+
 ### Run iOS/Android using Visual Studio
 - create launch.json and add below
 ```
@@ -33,7 +45,7 @@ flutter packages pub run build_runner build --delete-conflicting-outputs
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "flutter_template_riverpod(development mode)",
+      "name": "flutter_template_riverpod (development mode)",
       "request": "launch",
       "type": "dart",
       "program": "lib/main/main_development.dart",

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		82B3057E290109E5000CC069 /* Debug-Production */ = {
+		82B3057E290109E5000CC069 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -359,9 +359,9 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = "Debug-Production";
+			name = Debug;
 		};
-		82B3057F290109E5000CC069 /* Debug-Production */ = {
+		82B3057F290109E5000CC069 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
@@ -384,9 +384,9 @@
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Debug-Production";
+			name = Debug;
 		};
-		82B3058229010A00000CC069 /* Release-Production */ = {
+		82B3058229010A00000CC069 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -436,9 +436,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = "Release-Production";
+			name = Release;
 		};
-		82B3058329010A00000CC069 /* Release-Production */ = {
+		82B3058329010A00000CC069 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
@@ -460,7 +460,7 @@
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Release-Production";
+			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
@@ -468,20 +468,20 @@
 		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				82B3057E290109E5000CC069 /* Debug-Production */,
-				82B3058229010A00000CC069 /* Release-Production */,
+				82B3057E290109E5000CC069 /* Debug */,
+				82B3058229010A00000CC069 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "Debug-Production";
+			defaultConfigurationName = Debug;
 		};
 		97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				82B3057F290109E5000CC069 /* Debug-Production */,
-				82B3058329010A00000CC069 /* Release-Production */,
+				82B3057F290109E5000CC069 /* Debug */,
+				82B3058329010A00000CC069 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "Debug-Production";
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -306,86 +306,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		82B3057C290109C5000CC069 /* Debug-Development */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Debug-Development";
-		};
-		82B3057D290109C5000CC069 /* Debug-Development */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
-			buildSettings = {
-				APP_DISPLAY_NAME = "[DEV] Flutter Template Riverpod";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
-				ENABLE_BITCODE = NO;
-				FLUTTER_TARGET = lib/main/main_development.dart;
-				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.monstarlab.oss.flutter.template.flutter-template-riverpod.dev";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Debug-Development";
-		};
 		82B3057E290109E5000CC069 /* Debug-Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -465,82 +385,6 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Debug-Production";
-		};
-		82B30580290109F1000CC069 /* Release-Development */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = "Release-Development";
-		};
-		82B30581290109F1000CC069 /* Release-Development */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
-			buildSettings = {
-				APP_DISPLAY_NAME = "[DEV] Flutter Template Riverpod";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
-				ENABLE_BITCODE = NO;
-				FLUTTER_TARGET = lib/main/main_development.dart;
-				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.monstarlab.oss.flutter.template.flutter-template-riverpod.dev";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Release-Development";
 		};
 		82B3058229010A00000CC069 /* Release-Production */ = {
 			isa = XCBuildConfiguration;
@@ -625,9 +469,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				82B3057E290109E5000CC069 /* Debug-Production */,
-				82B3057C290109C5000CC069 /* Debug-Development */,
 				82B3058229010A00000CC069 /* Release-Production */,
-				82B30580290109F1000CC069 /* Release-Development */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Debug-Production";
@@ -636,9 +478,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				82B3057F290109E5000CC069 /* Debug-Production */,
-				82B3057D290109C5000CC069 /* Debug-Development */,
 				82B3058329010A00000CC069 /* Release-Production */,
-				82B30581290109F1000CC069 /* Release-Development */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Debug-Production";

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
 				ENABLE_BITCODE = NO;
+				FLUTTER_TARGET = lib/main/main_development.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -450,6 +451,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
 				ENABLE_BITCODE = NO;
+				FLUTTER_TARGET = lib/main/main_development.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -526,6 +528,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
 				ENABLE_BITCODE = NO;
+				FLUTTER_TARGET = lib/main/main_development.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -601,6 +604,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
 				ENABLE_BITCODE = NO;
+				FLUTTER_TARGET = lib/main/main_development.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		82B3057E290109E5000CC069 /* Debug */ = {
+		82B3057E290109E5000CC069 /* Debug-Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -359,9 +359,9 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Debug;
+			name = "Debug-Development";
 		};
-		82B3057F290109E5000CC069 /* Debug */ = {
+		82B3057F290109E5000CC069 /* Debug-Development */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
@@ -384,9 +384,9 @@
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = Debug;
+			name = "Debug-Development";
 		};
-		82B3058229010A00000CC069 /* Release */ = {
+		82B3058229010A00000CC069 /* Release-Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -436,9 +436,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = "Release-Production";
 		};
-		82B3058329010A00000CC069 /* Release */ = {
+		82B3058329010A00000CC069 /* Release-Production */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
@@ -460,7 +460,7 @@
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = Release;
+			name = "Release-Production";
 		};
 /* End XCBuildConfiguration section */
 
@@ -468,20 +468,20 @@
 		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				82B3057E290109E5000CC069 /* Debug */,
-				82B3058229010A00000CC069 /* Release */,
+				82B3057E290109E5000CC069 /* Debug-Development */,
+				82B3058229010A00000CC069 /* Release-Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = "Debug-Development";
 		};
 		97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				82B3057F290109E5000CC069 /* Debug */,
-				82B3058329010A00000CC069 /* Release */,
+				82B3057F290109E5000CC069 /* Debug-Development */,
+				82B3058329010A00000CC069 /* Release-Production */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = "Debug-Development";
 		};
 /* End XCConfigurationList section */
 	};

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Template Riverpod";
+				APP_DISPLAY_NAME = "DevFlutter Template Riverpod";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -377,7 +377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.monstarlab.oss.flutter.template.flutter-template-riverpod";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.monstarlab.oss.flutter.template.flutter-template-riverpod-debug";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -442,7 +442,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "Flutter Template Riverpod";
+				APP_DISPLAY_NAME = "ProdFlutter Template Riverpod";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "DevFlutter Template Riverpod";
+				APP_DISPLAY_NAME = "[Dev]Flutter Template Riverpod";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -442,7 +442,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
-				APP_DISPLAY_NAME = "ProdFlutter Template Riverpod";
+				APP_DISPLAY_NAME = "[Prod]Flutter Template Riverpod";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 9ZD9D8JG7K;
 				ENABLE_BITCODE = NO;
-				FLUTTER_TARGET = lib/main/main_development.dart;
+				FLUTTER_TARGET = lib/main/main_production.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,7 +52,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-Development"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -69,10 +69,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug-Development">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug-Development"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug-Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug-Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,7 +52,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release-Development"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -69,10 +69,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug-Development">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release-Development"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug-Production"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug-Production"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,7 +52,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release-Production"
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -69,10 +69,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug-Production">
+      buildConfiguration = "Release">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release-Production"
+      buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Release-Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release-Production"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,7 +52,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Release-Production"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -69,10 +69,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Release">
+      buildConfiguration = "Release-Production">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Release-Production"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -43,9 +47,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/lib/main/main_common.dart
+++ b/lib/main/main_common.dart
@@ -8,6 +8,7 @@ import '../presentation/app.dart';
 import 'app_flavor.dart';
 
 void mainCommon(AppFlavor appFlavor) {
+  debugPrint('launching....mode.... ${appFlavor.appFlavorType}');
   WidgetsFlutterBinding.ensureInitialized();
   Future<void> startApp() async {
     runApp(

--- a/lib/main/main_common.dart
+++ b/lib/main/main_common.dart
@@ -8,7 +8,7 @@ import '../presentation/app.dart';
 import 'app_flavor.dart';
 
 void mainCommon(AppFlavor appFlavor) {
-  debugPrint('launching....mode.... ${appFlavor.appFlavorType}');
+  debugPrint('Launching Mode : ${appFlavor.appFlavorType}.');
   WidgetsFlutterBinding.ensureInitialized();
   Future<void> startApp() async {
     runApp(


### PR DESCRIPTION
**What**  
- Added simple pr template
- Fixed to run from vs code
- Fixed to run from xcode
- Fixed app bundler identifier and display name
- Keep only Development and Release mode same as android
  Development -> com.monstarlab.oss.flutter.template.flutter-template-riverpod-debug
  Release -> com.monstarlab.oss.flutter.template.flutter-template-riverpod

**Screen shots**  
Xcode config
<img width="712" alt="Screen Shot 2022-11-08 at 15 09 47" src="https://user-images.githubusercontent.com/14831652/200488756-2981032b-ea42-4ba1-86ef-d590a988e61d.png">
Xcode config
<img width="711" alt="Screen Shot 2022-11-08 at 15 09 33" src="https://user-images.githubusercontent.com/14831652/200488295-4d415ab9-50af-4273-8492-914fa8ca03a8.png">

Printed logs to show which mode is running
<img width="902" alt="image" src="https://user-images.githubusercontent.com/14831652/200488595-c9b38f34-9b15-43ff-960d-db65971c8bc0.png">

Launcher app name
![Simulator Screen Shot - iPhone Xs Max - 2022-11-08 at 15 22 15](https://user-images.githubusercontent.com/14831652/200490134-747f5e17-5db6-4dc0-875b-1b420cd88fa9.png)

Run config file 
<img width="989" alt="image" src="https://user-images.githubusercontent.com/14831652/200491997-cdecd2d2-cf5a-407f-9c98-0d8b789ea6e1.png">
**Api logs**  
- NA


**Other logs**  
Why Debug-Development and Release-Production names
when run using vs code shows below 
The Xcode project defines build configurations: Debug, Release
Flutter expects a build configuration named Debug-Development or similar.
Open Xcode to fix the problem:
  open ios/Runner.xcworkspace

