### PR TITLE
Implemented dark light theme in setting and use on home title bar

### DIFF
--- a/lib/constants/resources/colors.dart
+++ b/lib/constants/resources/colors.dart
@@ -61,6 +61,19 @@ class AppColors {
     lightBlue: Color(0x03A9F4FF),
     mediumBlue: Color(0xFF1976D2),
   );
+  static const dark = AppColors(
+    mainText: Color(0xFFF1F5F1),
+    subTextDark: Color(0xFF688690),
+    subTextLight: Color(0xFFB5C3C9),
+    border: Color(0xFFA7C0CC),
+    disable: Color(0xFFE7E9EB),
+    white: Color(0xFFFFFFFF),
+    black: Color(0xFF000000),
+    lightBlack: Color(0x1F000000),
+    mediumBlack: Color(0x73000000),
+    lightBlue: Color(0x03A9F4FF),
+    mediumBlue: Color(0xFF1976D2),
+  );
 }
 
 extension AppColorsExtension on BuildContext {

--- a/lib/constants/resources/themes.dart
+++ b/lib/constants/resources/themes.dart
@@ -3,15 +3,17 @@ import 'package:flutter/material.dart';
 import 'resources.dart';
 
 class Themes {
-  static ThemeData appTheme() {
+  static ThemeData appTheme(Brightness brightness) {
+    final colors =
+        brightness == Brightness.light ? AppColors.light : AppColors.dark;
     return ThemeData(
       appBarTheme: AppBarTheme(
         centerTitle: false,
-        color: AppColors.light.white,
+        color: colors.white,
         toolbarTextStyle: AppTextStyles.hiraginoSansRegular11
-            .copyWith(color: AppColors.light.mainText),
+            .copyWith(color: colors.mainText),
         titleTextStyle: AppTextStyles.hiraginoSansRegular12
-            .copyWith(color: AppColors.light.mainText),
+            .copyWith(color: colors.mainText),
       ),
     );
   }

--- a/lib/presentation/app.dart
+++ b/lib/presentation/app.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../constants/resources/themes.dart';
 import '../main/app_flavor.dart';
+import 'common/app_shared_preference.dart';
+import 'common/app_theme_provider.dart';
 import 'feature/home/home_page.dart';
 
 class App extends ConsumerStatefulWidget {
@@ -21,15 +23,23 @@ class _AppState extends ConsumerState<App> {
   @override
   void initState() {
     super.initState();
+    init();
+  }
+
+  Future<void> init() async {
+    await AppSharedPreferences.init();
   }
 
   @override
   Widget build(BuildContext context) {
+    final isDarkTheme = ref.watch(appThemeNotifierProvider);
     return Builder(
       builder: (context) {
         return MaterialApp(
           // debugShowCheckedModeBanner: false,
-          theme: Themes.appTheme(),
+          theme: Themes.appTheme(Brightness.light),
+          darkTheme: Themes.appTheme(Brightness.dark),
+          themeMode: isDarkTheme ? ThemeMode.dark : ThemeMode.light,
           // localizationsDelegates: AppLocalizations.localizationsDelegates,
           // supportedLocales: AppLocalizations.supportedLocales,
           title: 'MonstarLab Riverpod Template',

--- a/lib/presentation/common/app_shared_preference.dart
+++ b/lib/presentation/common/app_shared_preference.dart
@@ -1,0 +1,24 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum AppPreferenceKeys {
+  isDarkTheme,
+}
+
+class AppSharedPreferences {
+  static SharedPreferences? _sharedPreferences;
+
+  static Future<SharedPreferences> init() async {
+    _sharedPreferences = await SharedPreferences.getInstance();
+    return _sharedPreferences!;
+  }
+
+  static Future<void> saveIsDarkTheme(bool isDark) async =>
+      _sharedPreferences!.setBool(
+        AppPreferenceKeys.isDarkTheme.name,
+        isDark,
+      );
+
+  static bool? getIsDarkTheme() => _sharedPreferences!.getBool(
+        AppPreferenceKeys.isDarkTheme.name,
+      );
+}

--- a/lib/presentation/common/app_theme_provider.dart
+++ b/lib/presentation/common/app_theme_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app_shared_preference.dart';
+
+final appThemeNotifierProvider =
+    StateNotifierProvider.autoDispose<AppThemeStateNotifier, bool>((ref) {
+  return AppThemeStateNotifier();
+});
+
+class AppThemeStateNotifier extends StateNotifier<bool> {
+  AppThemeStateNotifier() : super(false) {
+    // set initially set value
+    Future.delayed(Duration.zero, () async {
+      state = AppSharedPreferences.getIsDarkTheme() ?? false;
+    });
+  }
+
+  void setIsDarkTheme(bool isDarkTheme) {
+    state = isDarkTheme;
+    AppSharedPreferences.saveIsDarkTheme(isDarkTheme);
+  }
+}

--- a/lib/presentation/feature/home/home_page.dart
+++ b/lib/presentation/feature/home/home_page.dart
@@ -16,7 +16,7 @@ class HomePage extends BasePage {
 class _HomePageState extends BasePageState<HomePage>
     with WidgetsBindingObserver {
   int _currentIndex = 0;
-  final List _screens = [const NewsPage(), const ProfilePage()];
+  final List _screens = const [NewsPage(), ProfilePage()];
 
   void _updateIndex(int value) {
     setState(() {
@@ -37,7 +37,7 @@ class _HomePageState extends BasePageState<HomePage>
         type: BottomNavigationBarType.fixed,
         currentIndex: _currentIndex,
         onTap: _updateIndex,
-        selectedItemColor: AppColors.light.mediumBlue,
+        selectedItemColor: context.colors.mediumBlue,
         selectedFontSize: 13,
         unselectedFontSize: 13,
         iconSize: 30,

--- a/lib/presentation/feature/profile/profile_page.dart
+++ b/lib/presentation/feature/profile/profile_page.dart
@@ -1,10 +1,36 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ProfilePage extends StatelessWidget {
-  const ProfilePage({Key? key}) : super(key: key);
+import '../../common/app_theme_provider.dart';
+
+class ProfilePage extends ConsumerWidget {
+  const ProfilePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Center(child: Text('Profile Page'));
+  Widget build(BuildContext context, WidgetRef ref) {
+    var isDarkTheme = ref.watch(appThemeNotifierProvider);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Container(
+        color: Colors.greenAccent,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text(
+              'Dark Mode',
+            ),
+            Switch(
+              value: isDarkTheme,
+              onChanged: (value) {
+                isDarkTheme = value;
+                ref
+                    .read(appThemeNotifierProvider.notifier)
+                    .setIsDarkTheme(value);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/feature/profile/profile_page.dart
+++ b/lib/presentation/feature/profile/profile_page.dart
@@ -8,7 +8,7 @@ class ProfilePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var isDarkTheme = ref.watch(appThemeNotifierProvider);
+    final isDarkTheme = ref.watch(appThemeNotifierProvider);
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Container(
@@ -22,7 +22,6 @@ class ProfilePage extends ConsumerWidget {
             Switch(
               value: isDarkTheme,
               onChanged: (value) {
-                isDarkTheme = value;
                 ref
                     .read(appThemeNotifierProvider.notifier)
                     .setIsDarkTheme(value);


### PR DESCRIPTION
### Issue

- Need light dark mode setting.

### Motivation and Context

- Need light dark mode setting.

### Modified points

- Save dark mode setting in preference.
- Restore setting after app open.
- Change the color of title bar based on theme setting.
- Copy past same color as light in dark theme. Modified single color to show the implementation.

### Description and Screenshots
- demo
https://user-images.githubusercontent.com/14831652/202602994-7c366b90-8b75-47d9-ba6e-b1fcaa00faa9.mov
- on off state - title bar color changed.
![Simulator Screen Shot - iPhone Xs Max - 2022-11-18 at 11 29 14](https://user-images.githubusercontent.com/14831652/202603046-556155a2-c250-44fb-8624-b499f55b68df.png)
![Simulator Screen Shot - iPhone Xs Max - 2022-11-18 at 11 29 19](https://user-images.githubusercontent.com/14831652/202603055-d1d6eca4-d2c0-4d78-9dd8-219bd734a0b5.png)

### Figma or screen image URL
- NA


### Worries or Issues

- `(optional)`