### PR TITLE
Update intl library to 0.18.0

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -72,7 +72,6 @@ linter:
     - hash_and_equals
     - implementation_imports
     - iterable_contains_unrelated_type
-    - invariant_booleans
     - join_return_with_assignment
     - library_names
     - library_prefixes
@@ -91,7 +90,6 @@ linter:
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -229,10 +229,12 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -260,6 +262,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/lib/constants/resources/font_sizes.dart
+++ b/lib/constants/resources/font_sizes.dart
@@ -45,8 +45,7 @@ extension FontSizesExtension on FontSizes {
   }
 
   double getRelativeFontSize() {
-    final window = WidgetsBinding.instance.window;
-    final scaleFactor = MediaQueryData.fromWindow(window).size.width /
+    final scaleFactor = MediaQueryData.fromView(WidgetsBinding.instance.platformDispatcher.views.single).size.width /
         Constants.figmaScreenWidth;
     return fontSize * (scaleFactor >= 1 ? 1 : scaleFactor);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ version: 1.0.0+1
 
 environment:
   sdk: '>=2.18.2 <3.3.0'
+  flutter: '3.10.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.10.0'
+  sdk: '>=2.18.2 <3.3.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.2 <3.3.0'
+  sdk: '>=3.10.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dev_dependencies:
   # Generate interface to APIs
   retrofit_generator: '>=4.0.0 <5.0.0'
   # Generate providers for Riverpod
-  intl: ^0.17.0 
+  intl: ^0.18.0
   riverpod_generator: ^1.0.6
   mockito: ^5.3.2
 


### PR DESCRIPTION
### Issue

- The project was not compiling because of the following error

```
Because flutter_template_riverpod depends on flutter_localizations from sdk which depends on intl 0.18.0, intl 0.18.0 is required.
```

- Other deprecation issues arise during automatic tests. They have also been solved in here.
- The project was giving building issues with old Flutter versions

### Motivation and Context

- Update the library to the required version and it makes the project to compile
- Delete some removed lints
- Solve an issue with the use of window
- Add a Flutter minimum target

### Modified points

- [x] Change intl library from 0.17 -> 0.18 