### PR TITLE
Update libraries

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,19 +20,19 @@ dependencies:
   # Handle the complexity of asynchronous networking calls to REST APIs
   retrofit: ^4.0.1
   # Most popular Http Client
-  dio: ^5.3.1
+  dio: ^5.3.2
   #Declarative Routing Package
   go_router: ^10.0.0
   # Code generation for immutable classes
   freezed: ^2.2.1
   freezed_annotation: ^2.2.0
   # Generate code for converting to and from JSON via annotation
-  json_serializable: ^6.5.4
-  json_annotation: ^4.7.0
+  json_serializable: ^6.7.1
+  json_annotation: ^4.8.1
   # Shared Preferences
-  shared_preferences: ^2.0.15
+  shared_preferences: ^2.2.0
   # Log network calls in a pretty, easy to read format
-  pretty_dio_logger: ^1.1.1
+  pretty_dio_logger: ^1.3.1
   # Logger that prints beautiful logs
   logger: ^2.0.1
 
@@ -40,11 +40,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   # Official linter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.2
   # Essential for file generation at build time
   build_runner: any
   # Safely use assets, fonts etc without string paths
-  flutter_gen_runner: ^5.1.0+1
+  flutter_gen_runner: ^5.3.1
   # Generate interface to APIs
   retrofit_generator: ^7.0.8
   # Generate providers for Riverpod

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,15 +17,13 @@ dependencies:
   # Superior state management
   flutter_riverpod: ^2.1.1
   riverpod_annotation: ^1.0.6
+  freezed_annotation: ^2.2.0
   # Handle the complexity of asynchronous networking calls to REST APIs
   retrofit: ^4.0.1
   # Most popular Http Client
   dio: ^5.3.2
   #Declarative Routing Package
   go_router: ^10.0.0
-  # Code generation for immutable classes
-  freezed: ^2.2.1
-  freezed_annotation: ^2.2.0
   # Generate code for converting to and from JSON via annotation
   json_serializable: ^6.7.1
   json_annotation: ^4.8.1
@@ -39,10 +37,11 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  # Essential for file generation at build time
+  freezed:
+  build_runner:
   # Official linter
   flutter_lints: ^2.0.2
-  # Essential for file generation at build time
-  build_runner: any
   # Safely use assets, fonts etc without string paths
   flutter_gen_runner: ^5.3.1
   # Generate interface to APIs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   # Superior state management
-  flutter_riverpod: ^2.1.1
-  riverpod_annotation: ^1.0.6
+  flutter_riverpod: ^2.2.0
+  riverpod_annotation: ^1.2.1
   freezed_annotation: ^2.2.0
   # Handle the complexity of asynchronous networking calls to REST APIs
   retrofit: ^4.0.1
@@ -48,8 +48,8 @@ dev_dependencies:
   retrofit_generator: ^7.0.8
   # Generate providers for Riverpod
   intl: ^0.18.0
-  riverpod_generator: ^1.0.6
-  mockito: ^5.3.2
+  riverpod_generator: ^1.1.1
+  mockito: ^5.4.2
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
### Motivation and Context

- Update pubspec with latest libraries
- There are new versions of the following libraries but they cannot be updated because of mutually incompatible dependencies.

```
Package Name         Current  Upgradable  Resolvable  Latest  

direct dependencies:
flutter_riverpod     *2.2.0   *2.2.0      *2.2.0      2.3.6   
riverpod_annotation  *1.2.1   *1.2.1      *1.2.1      2.1.1   

dev_dependencies:   
freezed              *2.4.1   *2.4.1      *2.4.1      2.4.2   
intl                 *0.18.0  *0.18.0     *0.18.0     0.18.1  
riverpod_generator   *1.1.1   *1.1.1      *1.1.1      2.2.5 
```

### Modified points

- [x] edit library version number where possible