### PR TITLE
Fix Zone mismatch message

### DIFF
--- a/lib/main/main_common.dart
+++ b/lib/main/main_common.dart
@@ -9,7 +9,7 @@ import 'app_flavor.dart';
 
 void mainCommon(AppFlavor appFlavor) {
   debugPrint('Launching Mode : ${appFlavor.appFlavorType}.');
-  WidgetsFlutterBinding.ensureInitialized();
+
   Future<void> startApp() async {
     runApp(
       ProviderScope(
@@ -25,6 +25,7 @@ void mainCommon(AppFlavor appFlavor) {
 
   runZonedGuarded(
     () {
+      WidgetsFlutterBinding.ensureInitialized();
       startApp();
     },
     (error, stackTrace) {


### PR DESCRIPTION
### Motivation and Context

The following error is appearing when the app is launched:

```
════════ Exception caught by Flutter framework ═════════════════════════════════
The following assertion was thrown during runApp:
Zone mismatch.

The Flutter bindings were initialized in a different zone than is now being used. This will likely cause confusion and bugs as any zone-specific configuration will inconsistently use the configuration of the original binding initialization zone or this zone based on hard-to-predict factors such as which zone was active when a particular callback was set.
It is important to use the same zone when calling `ensureInitialized` on the binding as when calling `runApp` later.
To make this warning fatal, set BindingBase.debugZoneErrorsAreFatal to true before the bindings are initialized (i.e. as the first statement in `void main() { }`).
When the exception was thrown, this was the stack
```

`ensureInitialized` has to be called within the `runZonedGuarded`

https://docs.flutter.dev/release/breaking-changes/zone-errors
https://stackoverflow.com/questions/76472459/how-do-i-fix-this-sentry-zone-mismatch-error

### Modified points

- [x] Call `ensureInitialized` inside `runZonedGuarded`